### PR TITLE
docs: Added md file that describes the tags for our commits

### DIFF
--- a/COMMIT.md
+++ b/COMMIT.md
@@ -1,0 +1,14 @@
+Document for Commit Structure
+===========================================================
+
+* `feat` - a new feature is introduced with the changes
+* `fix`- a bug fix has occurred
+* `chore` - changes that do not relate to a fix or feature and don't modify src or test files (for example updating dependencies)
+* `refactor` - refactored code that neither fixes a bug nor adds a feature
+* `docs` - updates to documentation such as a the README or other markdown files
+* `style` - changes that do not affect the meaning of the code, likely related to code formatting such as white-space, missing semi-colons, and so on.
+* `test` - including new or correcting previous tests
+* `perf` - performance improvements
+* `ci` - continuous integration related
+* `build` - changes that affect the build system or external dependencies
+* `revert` - reverts a previous commit


### PR DESCRIPTION
COMMIT.md contains the structure for how we should add tags to our commits to make them easier to understand.

Solves Issue #40 